### PR TITLE
Move basic auth to support docs compose file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.env
 *.sw*
 *.json
+*.DS_Store
 core/acme.json
 core/usersfile
 instances/supportdocs/docs

--- a/core/docker-compose.yml
+++ b/core/docker-compose.yml
@@ -23,4 +23,3 @@ services:
       - "traefik.http.middlewares.csrfHeader.headers.customrequestheaders.X-Forwarded-Proto=https"
       - "traefik.http.middlewares.csrfHeader.headers.customrequestheaders.X-Forwarded-Port=443"
       - "traefik.http.middlewares.csrfHeader.headers.customrequestheaders.X-Forwarded-Ssl=on"
-      - "traefik.http.middlewares.bauth.basicauth.usersfile=/usersfile"

--- a/instances/supportdocs/docker-compose.yml
+++ b/instances/supportdocs/docker-compose.yml
@@ -20,3 +20,4 @@ services:
       - "traefik.http.routers.docs.tls=true"
       - "traefik.http.routers.docs.tls.certresolver=leresolver"
       - "traefik.http.routers.docs.middlewares=bauth"
+      - "traefik.http.middlewares.bauth.basicauth.usersfile=/usersfile"


### PR DESCRIPTION
The usersfile was not working as it should be in the service being called and not traefik, which required a very minor change.

We need to disable `HTTPS` to test locally. To save time, copy the code below into the associated files:

1. Disable `HTTPS` in [traefik.toml](https://github.com/ideafast/stack/blob/master/core/traefik.toml) so the `toml` should look like:

```
[entryPoints]
  [entryPoints.web]
    address = ":80"

  [entryPoints.postgres]
    address = ":5432"

  [entryPoints.mysql]
    address = ":3306"

[providers.docker]
  network = "web"
```

2. Remove port `443` and `csrfHeader` middleware from core [docker-compose file](https://github.com/ideafast/stack/blob/master/core/docker-compose.yml):

```
  traefik:
    image: traefik:v2.2
    restart: unless-stopped
    container_name: traefik
    networks:
      - web
    ports:
      - "80:80"
    volumes:
      - "./traefik.toml:/traefik.toml"
      - "./acme.json:/acme.json"
      - "./usersfile:/usersfile"
      - "/var/run/docker.sock:/var/run/docker.sock:ro"
      # note: there is no basicauth label
```

2. Remove `https` from the service we want to run, i.e. [supportdocs](https://github.com/ideafast/stack/blob/master/instances/supportdocs/docker-compose.yml):

```
services:
  docs:
    image: nginx:alpine
    volumes:
      - ./conf:/etc/nginx/conf.d/
      - ./docs/_site:/usr/share/nginx/html/
    networks:
      - web
    container_name: docs
    labels:
      - "traefik.enable=true"
      - "traefik.http.routers.docs.entrypoints=web"
      - "traefik.http.routers.docs.rule=Host(`docs.localhost`)" # Note this changed
      - "traefik.http.routers.docs.middlewares=bauth"
       # note: the basicauth label was moved to here
      - "traefik.http.middlewares.bauth.basicauth.usersfile=/usersfile"
```

3. Create a `usersfiles` in `/stack/core` with dummy data, e.g. where the password is *password*:

```
drew:$2y$10$4GFGa91Rxi4F5TPPxPU.IezkyDRhQZdSzl6RfUVC.RUq4cUGeQZDm
```

3. `HTTPS` and redirects should now be disabled locally. To test if userfiles work locally:

- From the root (`/stack/`) run `docker-compose up -d` in `/core` and `/instances/supportdocs`. 
- Navigate to [docs.localhost](http://docs.localhost) and log in with username/password as `drew`/`password`

Closes #3 