### PR TITLE
Added MongoDB to middleware

### DIFF
--- a/instances/middleware/README.md
+++ b/instances/middleware/README.md
@@ -1,0 +1,35 @@
+## MongoDB Authentication
+
+Authentication is disabled in mongodb by default, and will need to be setup to access the db remotely. To do that: 
+
+1. Remove `command: [--auth]` from the `docker-compose.yml`.  
+2. Run `docker compose up -d` to see the changes. 
+3. Enter the docker container: `docker exec -it mongo bash`
+4. Run `mongo` from the command line and create two users as follows:
+
+```bash
+use admin
+db.createUser(
+    {
+        user: "ADMIN_USER",
+        pwd: "ROOT_PASSWORD",
+        roles:["root"]
+    }
+);
+
+use dtransfer
+db.createUser(
+    {
+        user: "DT_USER",
+        pwd: "DT_PASSWORD",
+        roles:[
+            {
+                role: "readWrite",
+                db: "dtransfer"
+            }
+        ]
+    }
+);
+```
+
+**Note**: change `user` and `pwd` with desired secrets.

--- a/instances/middleware/docker-compose.yml
+++ b/instances/middleware/docker-compose.yml
@@ -45,3 +45,6 @@ services:
       - mongodb:/data/db
     labels:
       - "traefik.enable=true"
+
+volumes:
+  mongodb:

--- a/instances/middleware/docker-compose.yml
+++ b/instances/middleware/docker-compose.yml
@@ -3,6 +3,8 @@ version: '3.8'
 networks:
   web:
     external: true
+  database:
+    external: true
 
 services:
   consumer_live:
@@ -30,3 +32,16 @@ services:
       - "traefik.http.routers.consumer_dev.rule=Host(`dev.api.wp3.ideafast.eu`)"
       - "traefik.http.routers.consumer_dev.entrypoints=websecure"
       - "traefik.http.routers.consumer_dev.tls.certresolver=leresolver"
+
+  mongodb:
+    container_name: mongo
+    image: mongo:4.4.3
+    command: [--auth]
+    networks:
+      - database
+    ports:
+      - 27017:27017
+    volumes:
+      - mongodb:/data/db
+    labels:
+      - "traefik.enable=true"


### PR DESCRIPTION
Added mongoDB for use between middleware services, e.g., consumer and dtransfer. This is being added now rather than with dtransfer so we can use it when running pipelines locally to ensure 'live' is kept in-sync.

## To Test

Can you access the database remotely? -> 🚀 