### PR TITLE
Adding ETL pipeline to the IDEAFAST stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ core/acme.json
 core/usersfile
 instances/supportdocs/docs
 instances/middleware/local
+instances/pipeline/init/connections.yaml
+instances/pipeline/init/variables.json
 data/
 local/
 *.log

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "instances/support/zammad"]
 	path = instances/support/zammad
 	url = https://github.com/zammad/zammad-docker-compose.git
+[submodule "instances/pipeline/ideafast_etl"]
+	path = instances/pipeline/ideafast_etl
+	url = https://github.com/ideafast/ideafast-etl

--- a/README.md
+++ b/README.md
@@ -1,116 +1,210 @@
-> This repo is a docker-compose stack to run the core services for idea-fast WP3.
+> _This repo is a docker-compose stack to run the core services for idea-fast WP3._
+
+## Global setup
 
 There are a couple of services defined here:
 
-- [core](./core) is the base services, e.g. reverse proxy.
-- [instances](./instances) are the instances of services we run, e.g. zammad.
+- [core](./core) is the reverse proxy using [traefik](https://doc.traefik.io/traefik/).
+- [instances](./instances) are the instances of services we run.
 
+The stack relies on three manually created docker networks. Check if these already exist, and, if not, create them:
 
-The [IDEAFAST/ETL pipeline](https://github.com/ideafast/ideafast-etl) and [Zammad](https://github.com/zammad/zammad-docker-compose) are used as a
-submodule to simplify working with their compose file. When you first download the repo the `/instances/pipeline/ideafast_etl` and `/instances/zammad` folders will be empty and you'll need to initialise it:
+```shell
+docker network list
 
-```
-git submodule update --init --recursive
-```
-
-## Deploying Stack
-
-```
 docker network create web
 docker network create database
 docker network create ideafast-etl
+```
 
-# Starting core services: traefik, sql, etc.
+## Local deployment/development
 
-cd core
+1. **Do not setup the TLS certification** as indicated below.
+1. Disable HTTP/S redirects and SSL by temporarily commenting the [associated Traefik config](https://github.com/ideafast/stack/blob/master/core/traefik.toml#L5-L10) in the [core/traefik.toml](core/traefik.toml) file on lines 5 - 10.
+1. _For each individual service you want to test_:
+    1. Update Traefik hosts labels to your local host in the `docker-compose.yml` files . For example, for the api, change `api.wp3.ideafast.eu` to `api.localhost`.
+    1. Comment out the Traefik `tls` and `entrypoint` labels: 
+        - `entrypoints=websecure`, 
+        - `tls=true`, and 
+        - `tls.certresolver=leresolver`.
 
-# Prepare file for certification via letsencrypt
+Spin up the reverse proxy and the service you want to test from their respective directories (as indicated below)
 
+### Reverse-proxy
+
+To setup [Treafik](https://doc.traefik.io/traefik/) for the reverse proxy, we need to enable TLS certification (via [Let's Encrypt](https://letsencrypt.org/)) to serve over HTTP**S**. Navigate to the [core](/core) directory, create a `acme.json` file with proper access permissions:
+
+```shell
+cd core 
 touch acme.json
 chmod 600 acme.json
+```
 
-# Create usersfile (to create user/password, see https://docs.traefik.io/middlewares/basicauth/)
+At this stage, the [supportdocs](/supportdocs) website uses basic authentication with a `usersfile` in the core directory. Differently, the [api](/api) uses environmental variables to handle this. Either way, until the support documentation website is deprecated, we need to create a `usersfile` and add usernames and password for access. In the [core](/core) directory, create a `usersfile` document, and add usernames and passwords (see how to create these on [the Treafik documentation](https://docs.traefik.io/middlewares/basicauth/)): 
 
+```shell
 touch usersfile
-vim usersfile
+nano usersfile # or vim, or something else
+# add username:passwords, save, and exit
+```
 
+Finally, spin up the reverse proxy:
+
+```shell
 docker-compose up -d
+```
 
-# Start instances of services: zammad, snipeit, etc.
+### Submodules and dependencies
 
-cd ../instances
+The [IDEAFAST/ETL pipeline](https://github.com/ideafast/ideafast-etl) and [Zammad](https://github.com/zammad/zammad-docker-compose) are used as a submodule to simplify working with their compose file. When you first download the repo the `/instances/pipeline/ideafast_etl` and `/instances/zammad` folders will be empty and you'll need to initialise it:
 
-# If no .env exists copy/edit zammad's as a base. see /instances/.env.example
-cp zammad/.env .env
+```shell
+git submodule update --init --recursive
+```
 
-docker-compose -f ./zammad/docker-compose.yml  -f docker-compose.yml up -d
+Updating submodules can be done by entering the following command. **Note, however,** that this _does not_ merges the update (i.e., the reference to a specific commit of the submodule) into the current directory. You can add `--merge` to this command, but unless you update this `stack` git repository, this will start to diverge. Alternatively, use the `--merge` parameter and push the changes to the repository, or execute this command on your local machine, push changes and pull down the overall `ideafast/stack` repository to achieve the same result.
 
-cd supportdocs/
+```shell
+git submodule update --remote # --merge
+```
 
-git clone git@github.com:ideafast/ideafast-devicesupportdocs-web.git docs
+## Deploying and updating services
 
-chmod 755 jekyll-build.sh && ./jekyll-build.sh
+Each instance slightly differs in the setup due to the dependency on an image, submodule or environmental variables. Please see instructions how to start and update each service below:
 
+**For each service**, navigate (`cd`) into the directory and follow the steps below
+
+### WP3-API
+
+To setup the service, the service needs some environmental variables to be set, and an `ssh` key to acces the private documentation repository.
+
+- Get the `ssh` keys onto the server (using, for example `scp`), as outlined in the [ideafast/wp3-api](https://github.com/ideafast/wp3-api) README.
+- copy the example file and fill in the environmental variables
+  ```shell
+  cp .env.example .env
+  # fill in the environmental variables in the created .env file
+  ```
+- spin up the container
+  ```shell
+  docker-compose up -d
+  ```
+
+#### Updating
+
+To get the latest updates to the [ideafast/wp3-api](https://github.com/ideafast/wp3-api) on the server:
+- in your local [ideafast/wp3-api](https://github.com/ideafast/wp3-api) repository, build a docker image and push to docker hub
+  ```
+  poetry run bump -b patch # or minor, or major
+  poetry run build
+  poetry run publish
+  ```
+- then, in this repository, navigate to the [instances/api](instances/api) directory, pull down the latest image and restart the container
+  ```shell
+  docker pull ideafast/wp3-api
+  docker-compose up -d
+  ```
+
+### Study Dashboard
+
+At this point, the study dashboard is a simple HTML placeholder. Deploy it by running"
+
+```shell
 docker-compose up -d
+```
 
-cd ../
+### Inventory
 
-cd pipeline/
+> Once the FS finishes, the inventory will be deprecated. 
 
+Set up can be achieved as follows _(instructions taken from prior documentation)_:
+
+```
+cp .snipeit.env.example .snipeit.env
+docker-compose up -d
+```
+Once the service is running, enter the container, create an artisan key:
+```
+docker exec -it snipeit sh
+php artisan key:generate
+```
+Copy this value , store this in the `.snipeit.env` and restart the container:
+```
+docker-compose up -d
+```
+
+### Middleware
+
+> Once the FS finishes, the middleware will be deprecated. 
+
+Duplicate the environmental variable files and fill in as appropriate
+```
+cp .consumer.env.example .consumer.live.env
+cp .dtransfer.env.example .dtransfer.live.env
+```
+Spin up the service
+```
+docker-compose up -d
+```
+The MongoDB requires some slight configuration if spun up the first time. See the [intances/middleware/README](intances/middleware/README.md) for more details.
+
+### ETL Pipeline
+
+The ETL Pipeline uses [ideafast/ideafast-etl](https://github.com/ideafast/ideafast-etl) as a submodule, particularly due to its depdency on Python scripts that are _not_ exported into the docker image. First, we need to set some required environmental variables and initial values for the pipeline. Copy the (nested) example files and fill appropriately:
+
+```shell
 cp .env.example .env
 cp /init/connections.yaml.example /init/connections.yaml
 cp /init/variables.json.example /init/variables.json
+```
 
-# change the above env and init variables as needed
-# then, start the docker container with the command
+The `docker-compose.yaml` file inside the submodule sets up the pipeline for us, though we need to alter some (network) settings slightly, for which we have an additional docker-compose.yaml file to override these. Spin up the service with:
 
-#! /usr/bin/env bash
+```shell
 docker-compose -f ideafast_etl/docker-compose.yaml --env-file .env -f docker-compose.yaml up -d
+```
+As we explicitely indicate the file to use (with the `-f` parameter), _shutting down_ the services requires the same:
+```shell
+docker-compose -f ideafast_etl/docker-compose.yaml --env-file .env -f docker-compose.yaml down
+```
 
-cd ../
+#### Updating
 
-cd surveys/
+If you want to update any environmental variables, connections or variables (as in the /init folder), simply apply the changes and run the same docker command as above. If you want to pull in changes to the Python scripts made in the [ideafast/ideafast-etl](https://github.com/ideafast/ideafast-etl), run:
 
-docker-compose up -d
+```shell
+git submodule update --remote
+```
 
-cd ../
+### Redirects
 
-cd api/
+> Once the FS finishes, the redirects will be deprecated. 
 
-docker-compose up -d
+### Support
 
-cd ../
+> Once the FS finishes, the support system will be deprecated. 
 
-cd inventory/
+Set up can be achieved as follows _(instructions taken from prior documentation)_:
 
-cp .snipeit.env.example .snipeit.env
+```
+# If no .env exists copy/edit zammad's as a base. see /instances/.env.example
+cp zammad/.env .env
+docker-compose -f ./zammad/docker-compose.yml  -f docker-compose.yml up -d
+```
 
-docker pull snipe/snipe-it:v4.9.2
+### Support Documentation
 
-docker-compose up -d
+> Once the FS finishes, the support system will be deprecated. 
 
-docker exec -it snipeit sh
+Set up can be achieved as follows _(instructions taken from prior documentation)_:
 
-php artisan key:generate
-
-# Replace APP_KEY in .env with outputted value
-
+```
+git clone git@github.com:ideafast/ideafast-devicesupportdocs-web.git docs
+chmod 755 jekyll-build.sh && ./jekyll-build.sh
 docker-compose up -d
 ```
 
-## Support Docs Redeployment
+### Surveys
 
-The Support Docs are currently redeployed once a day using the crontab command from within the supportdocs folder
 ```
-0 0 * * * ~/stack/instances/supportdocs/redeploy-docs.sh
+docker-compose up -d
 ```
-
-## Deploying/Testing Locally
-
-1. Disable HTTP/S redirects and SSL by temporarily [deleting the associated traefik config](https://github.com/ideafast/stack/blob/master/core/traefik.toml#L5-L10).
-2. Update traefik hosts, e.g. from `inventory.ideafast.eu` to `inventory.localhost` [see here](https://github.com/ideafast/stack/blob/master/instances/docker-compose.yml#L19).
-
-### Notes
-
-- A reverse proxy is used to override `zammad-nginx` to expose the zammad
-  servers to traefik. See the [docker-compose.yml](./instances/docker-compose.yml).

--- a/README.md
+++ b/README.md
@@ -6,10 +6,8 @@ There are a couple of services defined here:
 - [instances](./instances) are the instances of services we run, e.g. zammad.
 
 
-[Zammad](https://github.com/zammad/zammad-docker-compose) is used as a
-submodule to simplify working with their compose file. When you first download
-the repo the `/instances/zammad` folder will be empty and you'll need to
-initialise it:
+The [IDEAFAST/ETL pipeline](https://github.com/ideafast/ideafast-etl) and [Zammad](https://github.com/zammad/zammad-docker-compose) are used as a
+submodule to simplify working with their compose file. When you first download the repo the `/instances/pipeline/ideafast_etl` and `/instances/zammad` folders will be empty and you'll need to initialise it:
 
 ```
 git submodule update --init --recursive
@@ -54,6 +52,20 @@ git clone git@github.com:ideafast/ideafast-devicesupportdocs-web.git docs
 chmod 755 jekyll-build.sh && ./jekyll-build.sh
 
 docker-compose up -d
+
+cd ../
+
+cd pipeline/
+
+cp .env.example .env
+cp /init/connections.yaml.example /init/connections.yaml
+cp /init/variables.json.example /init/variables.json
+
+# change the above env and init variables as needed
+# then, start the docker container with the command
+
+#! /usr/bin/env bash
+docker-compose -f ideafast_etl/docker-compose.yaml --env-file .env -f docker-compose.yaml up -d
 
 cd ../
 

--- a/instances/pipeline/.env.example
+++ b/instances/pipeline/.env.example
@@ -1,0 +1,19 @@
+AIRFLOW_UID=50000
+AIRFLOW_IMAGE_NAME=ideafast/etl:latest
+
+# --- USERS ---
+#   for local development, when changing log in values
+#   be sure to clean the docker volumes before rebooting
+_AIRFLOW_WWW_USER_USERNAME=username
+_AIRFLOW_WWW_USER_PASSWORD=password
+_MONGO_INITDB_ROOT_USERNAME=mongo_username
+_MONGO_INITDB_ROOT_PASSWORD=mongo_password
+
+# --- SECRETS ---
+# Generate Fernet key by running
+# ./airflow.sh python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)"
+_AIRFLOW__CORE__FERNET_KEY=""
+_WP3API_AIRFLOW_PASS=""
+
+# --- CONNECTIONS ---
+# update connections details in init/connections.yaml

--- a/instances/pipeline/docker-compose.yaml
+++ b/instances/pipeline/docker-compose.yaml
@@ -1,0 +1,28 @@
+version: '3.5'
+
+networks:
+  web:
+    external: true
+  ideafast-etl:
+    name: ideafast-etl
+    external: true
+
+services:
+  # ideafast-etl is a submodule. These settings are used to override for
+  # the stack purpose
+
+  airflow-webserver:
+    networks:
+      - web
+      - ideafast-etl
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.api.rule=Host(`pipeline.wp3.ideafast.eu`)"
+      - "traefik.http.routers.api.entrypoints=websecure"
+      - "traefik.http.routers.api.tls=true"
+      - "traefik.http.routers.api.tls.certresolver=leresolver"
+
+  ideafast-init:
+    volumes:
+      # use local init values  
+      - ../init:/opt/airflow/init/

--- a/instances/pipeline/docker-compose.yaml
+++ b/instances/pipeline/docker-compose.yaml
@@ -17,10 +17,10 @@ services:
       - ideafast-etl
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.api.rule=Host(`pipeline.wp3.ideafast.eu`)"
-      - "traefik.http.routers.api.entrypoints=websecure"
-      - "traefik.http.routers.api.tls=true"
-      - "traefik.http.routers.api.tls.certresolver=leresolver"
+      - "traefik.http.routers.pipeline.rule=Host(`pipeline.wp3.ideafast.eu`)"
+      - "traefik.http.routers.pipeline.entrypoints=websecure"
+      - "traefik.http.routers.pipeline.tls=true"
+      - "traefik.http.routers.pipeline.tls.certresolver=leresolver"
 
   ideafast-init:
     volumes:

--- a/instances/pipeline/init/connections.yaml.example
+++ b/instances/pipeline/init/connections.yaml.example
@@ -1,0 +1,51 @@
+# Example connections.yaml file that get's loaded when airflow spins up the first time
+# This add `connections` amd `variables` to Airflow, but if the container already spun up
+# before, leaves the (possibly adjusted) in place. See docker-file airflow-webserver
+
+dreem_kiel:
+  conn_type: JWT
+  description: "Custom API connection with Dreem servers"
+  host: deem_url_api
+  login: deem_user_kiel
+  password: dreem_pass_kiel
+  extra: |
+    {
+      "jwt_url": "dreem_token_url",
+      "jwt_token_path": "dict.path.to.token",
+      "user_id": "dreem_kiel_uid"
+    }
+  port: null
+  schema: null
+
+ucam_default:
+  conn_type: JWT
+  description: "Custom API connection with UCAM servers"
+  host: ucam_url_api
+  login: ucam_user
+  password: ucam_pass
+  extra: |
+    {
+      "jwt_url": "ucam_token_url",
+      "jwt_token_path": "dict.path.to.token"
+    }
+  port: null
+  schema: null
+
+dmp_default:
+  conn_type: JWT
+  description: "Custom API connection with ICL Data Management Portal"
+  host: dmp_url
+
+  # NOTE: the public key is too long for postrgres (VARCHAR(500)).
+  # to not mess with Postgress tables, refer to a key in extra (code will pick it up)
+  # be sure to escape newlines in the variable (i.e., \\n, not \n)
+  login: extra://public_key
+  password: signature
+  extra: |
+    {
+      "public_key": "public_key"
+      "jwt_url": "dmp_url"
+      "jwt_token_path": "dict.path.to.token"
+    }
+  port: null
+  schema: null

--- a/instances/pipeline/init/variables.json.example
+++ b/instances/pipeline/init/variables.json.example
@@ -1,0 +1,6 @@
+{
+  "dmp_dataset_mapping": {
+    "TEST": "dmp_test_dataset_id",
+    "COS": "dmp_cos_dataset_id"
+  }
+}


### PR DESCRIPTION
This PR pulls in the [ideafast/ideafast-etl](https://github.com/ideafast/ideafast-etl) pipeline into our stack, to be deployed on the server. It includes a major revamp of the README docs, for clarity how to set up _and update_ each service.